### PR TITLE
Allow zoxide_dir_popup() to actually cd into the selected path

### DIFF
--- a/zoxide_dir_popup.lua
+++ b/zoxide_dir_popup.lua
@@ -72,7 +72,7 @@ function zoxide_dir_popup(rl_buffer) -- luacheck: no global
         return
     end
 
-    local dir, shifted = selected:match("^ *[0-9.]+ +(.+)$")
+    local dir = selected
     if not dir or dir == "" then
         rl_buffer:ding()
         return


### PR DESCRIPTION
Minor edit (`zoxide` seems to provide only the path, without the score) to allow clink to cd into the selected path.