### PR TITLE
Add command to search for files matching pattern in current folder

### DIFF
--- a/ripgrep_popup.lua
+++ b/ripgrep_popup.lua
@@ -128,11 +128,11 @@ settings.add("ripgrep.show_preview", true, "Shows a preview window in fzf with f
     "If enabled it will also show a preview of the file using bat.\n"..
     "Expects bat command to be available in PATH.")
 
-settings.add("ripgrep.editor_executable", "%windir%\\notepad.exe", "Configures the editor to use to view the file when enter is pressed.",
+settings.add("ripgrep.editor_executable", "%windir%\\notepad.exe", "Configures the editor to use to view the file.",
     "Will only be taken into account if EDITOR environment variable is not set,\n"..
     "otherwise EDITOR env variable will be used.")
 
-settings.add("ripgrep.command", '"{editor}" "{file}"', "Configures the command to run when enter is pressed.",
+settings.add("ripgrep.command", '"{editor}" "{file}"', "Configures how to invoke the editor.",
     "Will use the editor path (ripgrep.editor_executable) as the executable, and can be used\n"..
     "to invoke the editor so it opens the file at the selected line, if the editor supports it.\n"..
 "You can use the following variables: {editor}, {line}, {file}.\n"..


### PR DESCRIPTION
Fix for #20 

Added a new tool that can search for files in current folder (and subfolders) matching a given pattern and allows you to open the editor when you hit enter.

Allows you to configure the editor to use as well as the command to invoke when you press enter.
Suggests some configuration options depending on your editor, as each editor has a different format for specifying how to open the file at a specific line (and not all of them support this).

Also provides the option to show a preview of the file around the matching string, highlighting the line as well - required `bat`.
You can also configure the size of the preview with `Ctrl + /`.

Defaults are set to notepad.

<img width="1908" height="763" alt="image" src="https://github.com/user-attachments/assets/1debf0cb-d4a4-4506-9556-4107ffaf0b13" />
